### PR TITLE
Added a way to get the XmlSchemaComplexType from XmlSchemaElement types so they could be inserted in the dictionary of the GetTagsByType method.

### DIFF
--- a/BeanSpitter/Utils/XmlSchemaObjectCollectionUtils.cs
+++ b/BeanSpitter/Utils/XmlSchemaObjectCollectionUtils.cs
@@ -28,7 +28,13 @@ namespace BeanSpitter.Utils
                 .ToArray();
             var types = schemaObjects
                 .Where(w => w.GetType() == typeof(XmlSchemaComplexType))
-                .ToArray();
+                .ToList();
+
+            var elementsWithComplexType = schemaObjects.Where(w => w.GetType() == typeof(XmlSchemaElement) &&
+                        ((XmlSchemaElement)w).SchemaType != null &&
+                        ((XmlSchemaElement)w).SchemaType.GetType() == typeof(XmlSchemaComplexType));
+
+            types.AddRange(elementsWithComplexType.Select(s => (XmlSchemaComplexType)((XmlSchemaElement)s).SchemaType));
 
             foreach (var item in xmlElements)
             {


### PR DESCRIPTION
Basically, the `GetTagsByType` method from [XmlSchemaObjectCollectionUtils.cs](https://github.com/cezarlamann/beanspitter/blob/master/BeanSpitter/Utils/XmlSchemaObjectCollectionUtils.cs), was not traversing the `SchemaType` property from a `XmlSchemaElement`. Now, by properly traversing the object, we could get all the Tags and their respective Types so the dictionary returned by the method is complete.

Also added a test to take care of this scenario.